### PR TITLE
Simple idea to deferr creation of endpoint info until its really needed!

### DIFF
--- a/src/oatpp/codegen/codegen_define_ApiController_.hpp
+++ b/src/oatpp/codegen/codegen_define_ApiController_.hpp
@@ -304,19 +304,19 @@ std::shared_ptr<Endpoint::Info> Z__EDNPOINT_INFO_GET_INSTANCE_##NAME() { \
 
 #define OATPP_MACRO_API_CONTROLLER_ENDPOINT_DECL_0(NAME, METHOD, PATH)  \
 \
-std::shared_ptr<Endpoint::Info> Z__CREATE_ENDPOINT_INFO_##NAME() { \
+EndpointInfoBuilder Z__CREATE_ENDPOINT_INFO_##NAME = [this](){ \
   auto info = Z__EDNPOINT_INFO_GET_INSTANCE_##NAME(); \
   info->name = #NAME; \
   info->path = PATH; \
   info->method = METHOD; \
   return info; \
-} \
+}; \
 \
 const std::shared_ptr<Endpoint> Z__ENDPOINT_##NAME = createEndpoint(m_endpoints, \
                                                         this, \
                                                         Z__ENDPOINT_METHOD_##NAME(this), \
                                                         nullptr, \
-                                                        Z__CREATE_ENDPOINT_INFO_##NAME());
+                                                        Z__CREATE_ENDPOINT_INFO_##NAME);
 
 #define OATPP_MACRO_API_CONTROLLER_ENDPOINT_0(NAME, METHOD, PATH) \
 OATPP_MACRO_API_CONTROLLER_ENDPOINT_DECL_DEFAULTS(NAME, METHOD, PATH) \
@@ -335,20 +335,20 @@ std::shared_ptr<oatpp::web::protocol::http::outgoing::Response> NAME()
 
 #define OATPP_MACRO_API_CONTROLLER_ENDPOINT_DECL_1(NAME, METHOD, PATH, ...)  \
 \
-std::shared_ptr<Endpoint::Info> Z__CREATE_ENDPOINT_INFO_##NAME() { \
-  auto info = Z__EDNPOINT_INFO_GET_INSTANCE_##NAME(); \
+EndpointInfoBuilder Z__CREATE_ENDPOINT_INFO_##NAME = [this](){ \
+auto info = Z__EDNPOINT_INFO_GET_INSTANCE_##NAME(); \
   info->name = #NAME; \
   info->path = PATH; \
   info->method = METHOD; \
   OATPP_MACRO_FOREACH(OATPP_MACRO_API_CONTROLLER_FOR_EACH_PARAM_INFO, __VA_ARGS__) \
   return info; \
-} \
+}; \
 \
 const std::shared_ptr<Endpoint> Z__ENDPOINT_##NAME = createEndpoint(m_endpoints, \
                                                         this, \
                                                         Z__ENDPOINT_METHOD_##NAME(this), \
                                                         nullptr, \
-                                                        Z__CREATE_ENDPOINT_INFO_##NAME());
+                                                        Z__CREATE_ENDPOINT_INFO_##NAME);
 
 #define OATPP_MACRO_API_CONTROLLER_ENDPOINT_1(NAME, METHOD, PATH, ...) \
 OATPP_MACRO_API_CONTROLLER_ENDPOINT_DECL_DEFAULTS(NAME, METHOD, PATH) \
@@ -421,19 +421,19 @@ std::shared_ptr<Endpoint::Info> Z__EDNPOINT_INFO_GET_INSTANCE_##NAME() { \
  */
 #define OATPP_MACRO_API_CONTROLLER_ENDPOINT_ASYNC_DECL(NAME, METHOD, PATH)  \
 \
-std::shared_ptr<Endpoint::Info> Z__CREATE_ENDPOINT_INFO_##NAME() { \
+EndpointInfoBuilder Z__CREATE_ENDPOINT_INFO_##NAME = [this](){ \
   auto info = Z__EDNPOINT_INFO_GET_INSTANCE_##NAME(); \
   info->name = #NAME; \
   info->path = PATH; \
   info->method = METHOD; \
   return info; \
-} \
+}; \
 \
 const std::shared_ptr<Endpoint> Z__ENDPOINT_##NAME = createEndpoint(m_endpoints, \
                                                                     this, \
                                                                     nullptr, \
                                                                     Z__ENDPOINT_METHOD_##NAME(this), \
-                                                                    Z__CREATE_ENDPOINT_INFO_##NAME());
+                                                                    Z__CREATE_ENDPOINT_INFO_##NAME);
 
 /**
  * Codegen macoro to be used in `oatpp::web::server::api::ApiController` to generate Asynchronous Endpoint.

--- a/src/oatpp/web/server/api/ApiController.cpp
+++ b/src/oatpp/web/server/api/ApiController.cpp
@@ -30,7 +30,7 @@ void ApiController::addEndpointsToRouter(const std::shared_ptr<Router>& router){
   auto node = m_endpoints->getFirstNode();
   while (node != nullptr) {
     auto endpoint = node->getData();
-    router->route(endpoint->info->method, endpoint->info->path, endpoint->handler);
+    router->route(endpoint->info()->method, endpoint->info()->path, endpoint->handler);
     node = node->getNext();
   }
 }

--- a/src/oatpp/web/server/api/ApiController.hpp
+++ b/src/oatpp/web/server/api/ApiController.hpp
@@ -139,6 +139,10 @@ public:
    * Convenience typedef for &id:oatpp::data::mapping::type::Boolean;.
    */
   typedef oatpp::data::mapping::type::Boolean Boolean;
+
+
+  typedef std::function<std::shared_ptr<Endpoint::Info>()> EndpointInfoBuilder;
+
   template <class T>
   using List = oatpp::data::mapping::type::List<T>;
   template <class Value>
@@ -225,9 +229,9 @@ public:
                                                   T* controller,
                                                   typename Handler<T>::Method method,
                                                   typename Handler<T>::MethodAsync methodAsync,
-                                                  const std::shared_ptr<Endpoint::Info>& info){
+                                                  const EndpointInfoBuilder &infoBuilder){
     auto handler = Handler<T>::createShared(controller, method, methodAsync);
-    auto endpoint = Endpoint::createShared(handler, info);
+    auto endpoint = Endpoint::createShared(handler, infoBuilder);
     endpoints->pushBack(endpoint);
     return endpoint;
   }

--- a/src/oatpp/web/server/api/Endpoint.cpp
+++ b/src/oatpp/web/server/api/Endpoint.cpp
@@ -99,14 +99,21 @@ oatpp::String Endpoint::Info::toString() {
 }
 
 Endpoint::Endpoint(const std::shared_ptr<RequestHandler>& pHandler,
-                   const std::shared_ptr<Info>& pInfo)
+                   const std::function<const std::shared_ptr<Endpoint::Info>&()> infoBuilder)
   : handler(pHandler)
-  , info(pInfo)
+  , m_infoBuilder(infoBuilder)
 {}
 
 std::shared_ptr<Endpoint> Endpoint::createShared(const std::shared_ptr<RequestHandler>& handler,
-                                                 const std::shared_ptr<Info>& info){
-  return std::make_shared<Endpoint>(handler, info);
+                                                 const std::function<const std::shared_ptr<Endpoint::Info>&()> infoBuilder){
+  return std::make_shared<Endpoint>(handler, infoBuilder);
+}
+
+std::shared_ptr<Endpoint::Info> Endpoint::info() {
+  if (m_info == nullptr) {
+    m_info = m_infoBuilder();
+  }
+  return m_info;
 }
 
 }}}}

--- a/src/oatpp/web/server/api/Endpoint.hpp
+++ b/src/oatpp/web/server/api/Endpoint.hpp
@@ -157,13 +157,18 @@ public:
   };
 public:
 
-  Endpoint(const std::shared_ptr<RequestHandler>& pHandler, const std::shared_ptr<Info>& pInfo);
+  Endpoint(const std::shared_ptr<RequestHandler>& pHandler, const std::function<const std::shared_ptr<Endpoint::Info>&()> infoBuilder);
   
   static std::shared_ptr<Endpoint> createShared(const std::shared_ptr<RequestHandler>& handler,
-                                                const std::shared_ptr<Info>& info);
+                                                const std::function<const std::shared_ptr<Endpoint::Info>&()> infoBuilder);
   
   const std::shared_ptr<RequestHandler> handler;
-  const std::shared_ptr<Info> info;
+
+  std::shared_ptr<Info> info();
+
+ private:
+  std::shared_ptr<Info> m_info;
+  const std::function<const std::shared_ptr<Endpoint::Info>&()> m_infoBuilder;
   
 };
   

--- a/test/oatpp/web/server/api/ApiControllerTest.cpp
+++ b/test/oatpp/web/server/api/ApiControllerTest.cpp
@@ -92,13 +92,13 @@ void ApiControllerTest::onRun() {
   {
     auto endpoint = controller.Z__ENDPOINT_root;
     OATPP_ASSERT(endpoint);
-    OATPP_ASSERT(endpoint->info->summary == "root_summary");
+    OATPP_ASSERT(endpoint->info()->summary == "root_summary");
 
-    auto r200 = endpoint->info->responses[Status::CODE_200];
+    auto r200 = endpoint->info()->responses[Status::CODE_200];
     OATPP_ASSERT(r200.contentType == "text/plain");
     OATPP_ASSERT(r200.schema == oatpp::String::Class::getType());
 
-    auto r404 = endpoint->info->responses[Status::CODE_404];
+    auto r404 = endpoint->info()->responses[Status::CODE_404];
     OATPP_ASSERT(r404.contentType == "text/plain");
     OATPP_ASSERT(r404.schema == oatpp::String::Class::getType());
 
@@ -115,19 +115,19 @@ void ApiControllerTest::onRun() {
   {
     auto endpoint = controller.Z__ENDPOINT_pathParams;
     OATPP_ASSERT(endpoint);
-    OATPP_ASSERT(!endpoint->info->summary);
+    OATPP_ASSERT(!endpoint->info()->summary);
 
-    OATPP_ASSERT(endpoint->info->pathParams["param1"].name == "param1");
-    OATPP_ASSERT(endpoint->info->pathParams["param1"].description == "this is param1");
+    OATPP_ASSERT(endpoint->info()->pathParams["param1"].name == "param1");
+    OATPP_ASSERT(endpoint->info()->pathParams["param1"].description == "this is param1");
 
-    OATPP_ASSERT(endpoint->info->pathParams["param2"].name == "param2");
-    OATPP_ASSERT(!endpoint->info->pathParams["param2"].description);
+    OATPP_ASSERT(endpoint->info()->pathParams["param2"].name == "param2");
+    OATPP_ASSERT(!endpoint->info()->pathParams["param2"].description);
 
-    OATPP_ASSERT(endpoint->info->queryParams["q1"].name == "q1");
-    OATPP_ASSERT(endpoint->info->queryParams["q1"].description == "query param");
+    OATPP_ASSERT(endpoint->info()->queryParams["q1"].name == "q1");
+    OATPP_ASSERT(endpoint->info()->queryParams["q1"].description == "query param");
 
-    OATPP_ASSERT(endpoint->info->headers["X-TEST-HEADER"].name == "X-TEST-HEADER");
-    OATPP_ASSERT(endpoint->info->headers["X-TEST-HEADER"].description == "TEST-HEADER-PARAM");
+    OATPP_ASSERT(endpoint->info()->headers["X-TEST-HEADER"].name == "X-TEST-HEADER");
+    OATPP_ASSERT(endpoint->info()->headers["X-TEST-HEADER"].description == "TEST-HEADER-PARAM");
 
     auto response = controller.pathParams("p1", "p2");
     OATPP_ASSERT(response->getStatus().code == 200);
@@ -142,13 +142,13 @@ void ApiControllerTest::onRun() {
   {
     auto endpoint = controller.Z__ENDPOINT_queryParams;
     OATPP_ASSERT(endpoint);
-    OATPP_ASSERT(!endpoint->info->summary);
+    OATPP_ASSERT(!endpoint->info()->summary);
 
-    OATPP_ASSERT(endpoint->info->queryParams["param1"].name == "param1");
-    OATPP_ASSERT(endpoint->info->queryParams["param1"].description == "this is param1");
+    OATPP_ASSERT(endpoint->info()->queryParams["param1"].name == "param1");
+    OATPP_ASSERT(endpoint->info()->queryParams["param1"].description == "this is param1");
 
-    OATPP_ASSERT(endpoint->info->queryParams["param2"].name == "param2");
-    OATPP_ASSERT(!endpoint->info->queryParams["param2"].description);
+    OATPP_ASSERT(endpoint->info()->queryParams["param2"].name == "param2");
+    OATPP_ASSERT(!endpoint->info()->queryParams["param2"].description);
 
     auto response = controller.queryParams("p1", "p2");
     OATPP_ASSERT(response->getStatus().code == 200);


### PR DESCRIPTION
Defer endpoint-info creation until its really needed! This way we can call functions in ENDPOINT_INFO that rely on external `ErrorHandler` oder `AuthorizationHandler`.
